### PR TITLE
Consistent error handling added to QModbusMaster

### DIFF
--- a/qmodbusmaster.cpp
+++ b/qmodbusmaster.cpp
@@ -40,173 +40,139 @@ QModbusMaster::~QModbusMaster ()
     modbus_free ((modbus_t *) ctx);
 }
 
-QModbusError & QModbusMaster::lastError ()
+bool QModbusMaster::setSlave (int slave)
 {
-    return modbusError;
+    return checkOperationsReturnValue( modbus_set_slave ((modbus_t *) ctx, slave) != 0 );
 }
 
-void QModbusMaster::setSlave (int slave)
+bool QModbusMaster::setBroadcast ()
 {
-    if (modbus_set_slave ((modbus_t *) ctx, slave) != 0) {
-        modbusError.set (errno);
-        qErrnoWarning (errno, modbus_strerror (errno));
-    }
-    else {
-        modbusError.clear ();
-    }
-}
-
-void QModbusMaster::setBroadcast ()
-{
-    if (modbus_set_slave((modbus_t *) ctx, MODBUS_BROADCAST_ADDRESS) != 0) {
-        modbusError.set (errno);
-        qErrnoWarning (errno, modbus_strerror (errno));
-    }
-    else {
-        modbusError.clear ();
-    }
+    return checkOperationsReturnValue( modbus_set_slave((modbus_t *) ctx, MODBUS_BROADCAST_ADDRESS) != 0 );
 }
 
 bool QModbusMaster::connect ()
 {
-    if (modbus_connect ((modbus_t *) ctx) != 0) {
-        modbusError.set (errno);
-        qErrnoWarning (errno, modbus_strerror (errno));
-        connected = false;
-    }
-    else {
-        modbusError.clear ();
-        connected = true;
-    }
-    return connected;
+    return checkOperationsReturnValue( modbus_connect ((modbus_t *) ctx) != 0 );
 }
 
 void QModbusMaster::close()
 {
     modbus_close ((modbus_t *) ctx);
+    modbusError.clear ();
 }
 
-void QModbusMaster::flush ()
+bool QModbusMaster::flush ()
 {
-    if (modbus_flush ((modbus_t *) ctx) != 0) {
-        modbusError.set (errno);
-        qErrnoWarning (errno, modbus_strerror (errno));
-    }
-    else {
-        modbusError.clear ();
-    }
+    return checkOperationsReturnValue( modbus_flush ((modbus_t *) ctx) != 0 );
 }
 
-void QModbusMaster::getByteTimeout (uint32_t *sec, uint32_t *usec)
+bool QModbusMaster::getByteTimeout (uint32_t *sec, uint32_t *usec)
 {
-    modbus_get_byte_timeout ((modbus_t *) ctx, sec, usec);
+    return checkOperationsReturnValue( modbus_get_byte_timeout ((modbus_t *) ctx, sec, usec) != 0 );
 }
 
-void QModbusMaster::setByteTimeout (uint32_t sec, uint32_t usec)
+bool QModbusMaster::setByteTimeout (uint32_t sec, uint32_t usec)
 {
-    modbus_set_byte_timeout ((modbus_t *) ctx, sec, usec);
+    return checkOperationsReturnValue( modbus_set_byte_timeout ((modbus_t *) ctx, sec, usec) != 0 );
 }
 
-void QModbusMaster::setDebug (bool debug)
+bool QModbusMaster::setDebug (bool debug)
 {
-    modbus_set_debug ((modbus_t *) ctx, (int)debug);
+    return checkOperationsReturnValue( modbus_set_debug ((modbus_t *) ctx, (int)debug) != 0 );
 }
 
-void QModbusMaster::setErrorRecovery (errorRecoveryMode errorRecovery)
+bool QModbusMaster::setErrorRecovery(errorRecoveryMode errorRecovery)
 {
-    if (!modbus_set_error_recovery ((modbus_t *) ctx, (modbus_error_recovery_mode)errorRecovery)) {
-        modbusError.set (errno);
-        qErrnoWarning (errno, modbus_strerror (errno));
-    }
-    else {
-        modbusError.clear ();
-    }
+    return checkOperationsReturnValue( modbus_set_error_recovery ((modbus_t *) ctx, (modbus_error_recovery_mode)errorRecovery) );
 }
 
 int QModbusMaster::getHeaderLength (void)
 {
+    // function simply returns data from ctx, as we ensure that ctx is always there and never nullptr,
+    // this call cannot fail
     return modbus_get_header_length ((modbus_t *) ctx);
 }
 
-void QModbusMaster::getResponseTimeout (uint32_t *sec, uint32_t *usec)
+bool QModbusMaster::getResponseTimeout (uint32_t *sec, uint32_t *usec)
 {
-    modbus_get_response_timeout ((modbus_t *) ctx, sec, usec);
+    return checkOperationsReturnValue( modbus_get_response_timeout ((modbus_t *) ctx, sec, usec) );
 }
 
-void QModbusMaster::setResponseTimeout (uint32_t sec, uint32_t usec)
+bool QModbusMaster::setResponseTimeout (uint32_t sec, uint32_t usec)
 {
-    modbus_set_response_timeout ((modbus_t *) ctx, sec, usec);
+    return checkOperationsReturnValue( modbus_set_response_timeout ((modbus_t *) ctx, sec, usec) );
 }
 
-void QModbusMaster::readBits (QModbusBits &bits)
+bool QModbusMaster::readBits (QModbusBits &bits)
 {
-    if(checkConnection()) {
-        checkOperationsReturnValue (modbus_read_bits ((modbus_t *) ctx, bits.addr, bits.size (), (quint8 *)bits.data ()));
-    }
+    if (!checkConnection())
+        return false;
+    return checkOperationsReturnValue (modbus_read_bits ((modbus_t *) ctx, bits.addr, bits.size (), (quint8 *)bits.data ()));
 }
 
-void QModbusMaster::readInputBits (QModbusBits &bits)
+bool QModbusMaster::readInputBits (QModbusBits &bits)
 {
-    if(checkConnection()) {
-        checkOperationsReturnValue (modbus_read_input_bits ((modbus_t *) ctx, bits.addr, bits.size (), (quint8 *)bits.data ()));
-    }
+    if (!checkConnection())
+        return false;
+    return checkOperationsReturnValue (modbus_read_input_bits ((modbus_t *) ctx, bits.addr, bits.size (), (quint8 *)bits.data ()));
 }
 
-void QModbusMaster::readRegisters (QModbusRegisters &regs)
+bool QModbusMaster::readRegisters (QModbusRegisters &regs)
 {
-    if(checkConnection()) {
-        checkOperationsReturnValue (modbus_read_registers ((modbus_t *) ctx, regs.addr, regs.size (), regs.data ()));
-    }
+    if (!checkConnection())
+        return false;
+    return checkOperationsReturnValue (modbus_read_registers ((modbus_t *) ctx, regs.addr, regs.size (), regs.data ()));
 }
 
-void QModbusMaster::readInputRegisters (QModbusRegisters &regs)
+bool QModbusMaster::readInputRegisters (QModbusRegisters &regs)
 {
-    if(checkConnection()) {
-        checkOperationsReturnValue (modbus_read_input_registers ((modbus_t *) ctx, regs.addr, regs.size (), regs.data ()));
-    }
+    if (!checkConnection())
+        return false;
+    return checkOperationsReturnValue (modbus_read_input_registers ((modbus_t *) ctx, regs.addr, regs.size (), regs.data ()));
 }
 
-void QModbusMaster::reportSlaveId (quint8 *dest)
+bool QModbusMaster::reportSlaveId (quint8 *dest)
 {
-    if(checkConnection()) {
-        checkOperationsReturnValue (modbus_report_slave_id ((modbus_t *) ctx, 1, dest));
-    }
+    if (!checkConnection())
+        return false;
+    return checkOperationsReturnValue (modbus_report_slave_id ((modbus_t *) ctx, 1, dest));
 }
 
-void QModbusMaster::writeBit (QModbusBits &bit)
+bool QModbusMaster::writeBit (QModbusBits &bit)
 {
-    if(checkConnection()) {
-        checkOperationsReturnValue (modbus_write_bit ((modbus_t *) ctx, bit.addr, bit.data ()[0]));
-    }
+    if (!checkConnection())
+        return false;
+    return checkOperationsReturnValue (modbus_write_bit ((modbus_t *) ctx, bit.addr, bit.data ()[0]));
 }
 
-void QModbusMaster::writeRegister (QModbusRegisters &reg)
+bool QModbusMaster::writeRegister (QModbusRegisters &reg)
 {
-    if(checkConnection()) {
-        checkOperationsReturnValue (modbus_write_register ((modbus_t *) ctx, reg.addr, (unsigned int)(reg.data ()[0])));
-    }
+    if (!checkConnection())
+        return false;
+    return checkOperationsReturnValue (modbus_write_register ((modbus_t *) ctx, reg.addr, (unsigned int)(reg.data ()[0])));
 }
 
-void QModbusMaster::writeBits (QModbusBits &bits)
+bool QModbusMaster::writeBits (QModbusBits &bits)
 {
-    if(checkConnection()) {
-        checkOperationsReturnValue (modbus_write_bits ((modbus_t *) ctx, bits.addr, bits.size(), (quint8 *)bits.data ()));
-    }
+    if (!checkConnection())
+        return false;
+    return checkOperationsReturnValue (modbus_write_bits ((modbus_t *) ctx, bits.addr, bits.size(), (quint8 *)bits.data ()));
 }
 
-void QModbusMaster::writeRegisters (QModbusRegisters &regs)
+bool QModbusMaster::writeRegisters (QModbusRegisters &regs)
 {
-    if(checkConnection()) {
-        checkOperationsReturnValue (modbus_write_registers ((modbus_t *) ctx, regs.addr, regs.size(), regs.data ()));
-    }
+    if (!checkConnection())
+        return false;
+    return checkOperationsReturnValue (modbus_write_registers ((modbus_t *) ctx, regs.addr, regs.size(), regs.data ()));
 }
 
-void QModbusMaster::writeAndReadRegisters (QModbusRegisters &writeRegs, QModbusRegisters &readRegs)
+bool QModbusMaster::writeAndReadRegisters (QModbusRegisters &writeRegs, QModbusRegisters &readRegs)
 {
-    if(checkConnection()) {
-        checkOperationsReturnValue (modbus_write_and_read_registers ((modbus_t *) ctx, writeRegs.addr, writeRegs.size (), writeRegs.data (), readRegs.addr, readRegs.size (), readRegs.data ()));
-    }
+    if (!checkConnection())
+        return false;
+    return checkOperationsReturnValue (modbus_write_and_read_registers ((modbus_t *) ctx, writeRegs.addr, writeRegs.size (), writeRegs.data (), readRegs.addr, readRegs.size (), readRegs.data ()));
 }
+
 
 // private
 void QModbusMaster::checkContext (void *ctx)
@@ -231,13 +197,14 @@ bool QModbusMaster::checkConnection ()
     return connected;
 }
 
-void QModbusMaster::checkOperationsReturnValue (int operationsReturnValue)
+bool QModbusMaster::checkOperationsReturnValue (int operationsReturnValue)
 {
     if (operationsReturnValue == -1) {
         modbusError.set (errno);
+        // TODO : think about using qcWarning() instead, to be able to filter out messages by context
         qErrnoWarning (errno, modbus_strerror (errno));
+        return false;
     }
-    else {
-        modbusError.clear ();
-    }
+    modbusError.clear ();
+    return true;
 }

--- a/qmodbusmaster.h
+++ b/qmodbusmaster.h
@@ -22,47 +22,56 @@ namespace Modbus
         QModbusMaster (const char *ip, int port, QObject* parent = 0);
         QModbusMaster (const char *device, int baud, char parity, int dataBit, int stopBit, QObject* parent = 0);
         QModbusMaster (const char *node, const char *service, QObject* parent = 0);
-        ~QModbusMaster ();
-        QModbusError & lastError ();
-        void setSlave (int slave);
-        void setBroadcast ();
+        ~QModbusMaster () override;
+        /*! Returns currently set modbus error, updated in last API call. */
+        inline const QModbusError & lastError () const { return modbusError; }
+        /*! Sets the slave ID. */
+        bool setSlave (int slave);
+        bool setBroadcast ();
         bool connect();
         void close ();
-        void flush ();
+        bool flush();
 
         //Context setters and getters
-        void getByteTimeout (uint32_t *sec, uint32_t *usec);
-        void setByteTimeout (uint32_t sec, uint32_t usec);
-        void setDebug (bool debug);
-        void setErrorRecovery (errorRecoveryMode errorRecovery);
+        bool getByteTimeout (uint32_t *sec, uint32_t *usec);
+        bool setByteTimeout(uint32_t sec, uint32_t usec);
+        bool setDebug(bool debug);
+        bool setErrorRecovery (errorRecoveryMode errorRecovery);
         int getHeaderLength (void);
-        void getResponseTimeout (uint32_t *sec, uint32_t *usec);
-        void setResponseTimeout (uint32_t sec, uint32_t usec);
+        bool getResponseTimeout(uint32_t *sec, uint32_t *usec);
+        bool setResponseTimeout(uint32_t sec, uint32_t usec);
 
         // Read data
-        void readBits (QModbusBits &bits);
-        void readInputBits (QModbusBits &bits);
-        void readRegisters (QModbusRegisters &regs);
-        void readInputRegisters (QModbusRegisters &regs);
-        void reportSlaveId (quint8 *dest);
+        bool readBits(QModbusBits &bits);
+        bool readInputBits(QModbusBits &bits);
+        bool readRegisters(QModbusRegisters &regs);
+        bool readInputRegisters(QModbusRegisters &regs);
+        bool reportSlaveId(quint8 *dest);
 
         // Write data
-        void writeBit (QModbusBits &bit);
-        void writeRegister (QModbusRegisters &reg);
-        void writeBits (QModbusBits &bits);
-        void writeRegisters (QModbusRegisters &regs);
+        bool writeBit(QModbusBits &bit);
+        bool writeRegister(QModbusRegisters &reg);
+        bool writeBits(QModbusBits &bits);
+        bool writeRegisters(QModbusRegisters &regs);
 
         // Write and read data
-        void writeAndReadRegisters (QModbusRegisters &writeRegs, QModbusRegisters &readRegs);
+        bool writeAndReadRegisters(QModbusRegisters &writeRegs, QModbusRegisters &readRegs);
 
     private:
         void *ctx;
         QModbusError modbusError;
         bool connected;
-        //
-        inline void checkContext (void *ctx);
-        inline bool checkConnection ();
-        inline void checkOperationsReturnValue (int returnValue);
+        /*! Checks for errno set by libmodus and configures modbusError accordingly. */
+        void checkContext (void *ctx);
+        /*! Checks if connection is established. If connected clears last error and returns true,
+            otherwise returns false and sets last error to NOT_CONNECTED_ENO.
+        */
+        bool checkConnection ();
+        /*! Checks if return value is != 0, and if so, sets the errno set by libmodbus and its message
+            as last modbusError.
+            \return Returns true, if returnValue == 0, or false, if != 0 (error).
+        */
+        bool checkOperationsReturnValue(int returnValue);
     };
 };
 

--- a/qmodbusmaster.h
+++ b/qmodbusmaster.h
@@ -22,7 +22,7 @@ namespace Modbus
         QModbusMaster (const char *ip, int port, QObject* parent = 0);
         QModbusMaster (const char *device, int baud, char parity, int dataBit, int stopBit, QObject* parent = 0);
         QModbusMaster (const char *node, const char *service, QObject* parent = 0);
-        ~QModbusMaster () override;
+        ~QModbusMaster ();
         /*! Returns currently set modbus error, updated in last API call. */
         inline const QModbusError & lastError () const { return modbusError; }
         /*! Sets the slave ID. */


### PR DESCRIPTION
This pull request adds:

- consistent error checking for all libmodus API calls within _QModbusMaster_ and according setting of modbusError
- return value on all API calls for easy of use:

```c++
// previously
modbusMaster->readBits(bits);
if (modbusMaster->lastError().isValid()) {
    // error handling
}

// now
if (!modbusMaster->readBits(bits)) {
    // error handling
}
```

- `lastError()` is now an inline function, as it is called extremely often in client code
- `ìnline` removed for not-inlined private functions
- `checkOperationsReturnValue()` is now being used consistently everywhere to wrap libmodbus API calls

**Note:** currently, `checkOperationsReturnValue()` always calls `qErrnoWarning()`, which could spam message logs. We should consider using `qCWarning(qmodbusCtx) << errno << ":" << message; `instead, as now users of QModbus can use filter rules to filter out qmodbus warnings.
